### PR TITLE
feat: 지식 자산 북마크(즐겨찾기) 기능 추가

### DIFF
--- a/ui/script.js
+++ b/ui/script.js
@@ -410,86 +410,199 @@ async function togBookmarkList() {
         }));
     }
 
+    // ── 지식 자산 북마크 조회 ──
+    let assetBookmarks = [];
+    const getAssetBm = window._getAssetBookmarks;
+    if (sb && getAssetBm) {
+        try {
+            const bmSet = getAssetBm();
+            if (bmSet.size > 0) {
+                const bmKeys = [...bmSet];
+                const assetDocIds = [...new Set(bmKeys.map(k => k.slice(0, k.lastIndexOf('_'))))];
+                if (assetDocIds.length > 0) {
+                    const { data: assets } = await sb
+                        .from('learning_assets')
+                        .select('id, type, document_id, documents(file_name)')
+                        .eq('status', 'DONE')
+                        .in('document_id', assetDocIds);
+                    if (assets) {
+                        assetBookmarks = assets.filter(a => bmSet.has(`${a.document_id}_${a.type}`));
+                    }
+                }
+            }
+        } catch (e) { console.warn('자산 북마크 로드 실패:', e.message); }
+    }
+
     grid.innerHTML = '';
 
-    if (!allBookmarks.length) {
+    const hasDocBm = allBookmarks.length > 0;
+    const hasAssetBm = assetBookmarks.length > 0;
+
+    if (!hasDocBm && !hasAssetBm) {
         grid.innerHTML = '<div style="grid-column:1/-1;text-align:center;color:#a0a6b0;padding:40px;">저장된 북마크가 없습니다.</div>';
         return;
     }
 
-    allBookmarks.forEach(bm => {
-        const colorCode = colorPalette.find(c => c.name === bm.color)?.code || '#ddd';
-        const isOtherDoc = bm.document_id !== window._currentDocId;
-        const card = document.createElement('div');
-        card.className = 'bm-card';
-        card.innerHTML = `
-            <div class="bm-card-top">
-                <span class="bm-dot" style="background:${colorCode};"></span>
-                ${isOtherDoc ? `<span style="font-size:10px;color:#94a3b8;margin-left:4px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:90px">${bm.documents?.file_name ?? ''}</span>` : ''}
-                <button class="bm-delete-btn" title="삭제" style="margin-left:auto;background:none;border:none;cursor:pointer;color:#cbd5e1;font-size:16px;line-height:1;padding:2px 4px;border-radius:6px;transition:.15s;">×</button>
-            </div>
-            <div class="bm-body">
-                <h3 class="bm-title">${bm.title || '제목 없음'}</h3>
-                <p class="bm-content">${bm.memo || '내용이 비어있습니다.'}</p>
-            </div>
+    // ── 지식 자산 북마크 섹션 ──
+    if (hasAssetBm) {
+        const assetHeader = document.createElement('div');
+        assetHeader.className = 'bm-section-header';
+        assetHeader.innerHTML = `
+            <svg viewBox="0 0 24 24" fill="none" stroke="#f59e0b" stroke-width="2" width="16" height="16">
+                <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" fill="#f59e0b"/>
+            </svg>
+            <span>지식 자산 북마크</span>
+            <span style="font-size:11px;font-weight:500;color:#94a3b8;">${assetBookmarks.length}개</span>
         `;
+        grid.appendChild(assetHeader);
 
-        // 삭제 버튼
-        card.querySelector('.bm-delete-btn').addEventListener('click', async (e) => {
-            e.stopPropagation();
-            if (bm.id) await deleteBookmarkFromDb(bm.id);
-            // 로컬 상태에서도 제거
-            const localEntry = Object.entries(bookmarksData).find(([, d]) => d.dbId === bm.id);
-            if (localEntry) {
-                const [localId, data] = localEntry;
-                document.getElementById(data.tagElementId)?.remove();
-                delete bookmarksData[localId];
-                saveBookmarks();
-            }
-            card.remove();
-            // 남은 카드 없으면 빈 메시지
-            if (!grid.querySelector('.bm-card')) {
-                grid.innerHTML = '<div style="grid-column:1/-1;text-align:center;color:#a0a6b0;padding:40px;">저장된 북마크가 없습니다.</div>';
-            }
+        const typeLabel = { SUMMARY: '요약', MINDMAP: '마인드맵', QUIZ: '퀴즈' };
+        const toolName  = { SUMMARY: 'summary', MINDMAP: 'mindmap', QUIZ: 'quiz' };
+
+        assetBookmarks.forEach(asset => {
+            const fname = (asset.documents?.file_name ?? '문서')
+                .replace(/^눈길\s*[-–—:]*\s*/i, '')
+                .replace(/\.(pdf|ppt|pptx)$/i, '').trim() || '문서';
+            const label = typeLabel[asset.type] ?? asset.type;
+            const assetKey = `${asset.document_id}_${asset.type}`;
+
+            const card = document.createElement('div');
+            card.className = 'bm-card asset-card';
+            card.innerHTML = `
+                <div class="bm-card-top">
+                    <span class="bm-asset-badge">
+                        <svg viewBox="0 0 24 24" fill="#f59e0b" stroke="#f59e0b" stroke-width="2" width="11" height="11">
+                            <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
+                        </svg>
+                        ${label}
+                    </span>
+                    <button class="bm-delete-btn" title="북마크 해제" data-asset-key="${assetKey}" style="margin-left:auto;background:none;border:none;cursor:pointer;color:#cbd5e1;font-size:16px;line-height:1;padding:2px 4px;border-radius:6px;transition:.15s;">×</button>
+                </div>
+                <div class="bm-body">
+                    <h3 class="bm-title">${fname}</h3>
+                    <p class="bm-content">${label} 자산을 열어 학습 내용을 확인하세요.</p>
+                </div>
+            `;
+
+            card.querySelector('.bm-delete-btn').addEventListener('click', (e) => {
+                e.stopPropagation();
+                const key = e.currentTarget.dataset.assetKey;
+                const saveFn = window._saveAssetBookmarks;
+                const getFn  = window._getAssetBookmarks;
+                if (saveFn && getFn) {
+                    const set = getFn(); set.delete(key); saveFn(set);
+                }
+                const sidebarStar = document.querySelector(`.sb-asset-bookmark[data-asset-key="${key}"]`);
+                if (sidebarStar) {
+                    sidebarStar.classList.remove('active');
+                    sidebarStar.textContent = '☆';
+                    sidebarStar.closest('.sb-item')?.classList.remove('asset-bookmarked');
+                }
+                card.remove();
+                if (!grid.querySelector('.bm-card.asset-card')) {
+                    grid.querySelector('.bm-section-header')?.remove();
+                }
+                if (!grid.querySelector('.bm-card')) {
+                    grid.innerHTML = '<div style="grid-column:1/-1;text-align:center;color:#a0a6b0;padding:40px;">저장된 북마크가 없습니다.</div>';
+                }
+            });
+
+            card.onclick = async () => {
+                overlay.classList.remove('show');
+                document.body.style.overflow = '';
+                if (asset.document_id !== window._currentDocId && typeof window.loadDocInViewer === 'function') {
+                    await window.loadDocInViewer(asset.document_id);
+                }
+                setTimeout(() => {
+                    const toolBtn = document.querySelector(`.sb-tool-item[data-ai-tool="${toolName[asset.type]}"]`);
+                    if (toolBtn) toolBtn.click();
+                }, 300);
+            };
+            grid.appendChild(card);
         });
-        card.onclick = async () => {
-            // 모달 닫기
-            overlay.classList.remove('show');
-            document.body.style.overflow = '';
+    }
 
-            if (isOtherDoc && typeof window.loadDocInViewer === 'function') {
-                // 다른 문서 로드 후 해당 위치로 스크롤
-                await window.loadDocInViewer(bm.document_id);
-                // 북마크 태그가 렌더링될 때까지 대기 후 스크롤
-                const waitAndScroll = (retries = 0) => {
-                    const tagEl = document.querySelector(`.bookmark-tag[data-db-id="${bm.id}"]`);
+    // ── 문서 북마크 섹션 ──
+    if (hasDocBm) {
+        if (hasAssetBm) {
+            const docHeader = document.createElement('div');
+            docHeader.className = 'bm-section-header';
+            docHeader.innerHTML = `
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16">
+                    <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/>
+                </svg>
+                <span>문서 북마크</span>
+                <span style="font-size:11px;font-weight:500;color:#94a3b8;">${allBookmarks.length}개</span>
+            `;
+            grid.appendChild(docHeader);
+        }
+
+        allBookmarks.forEach(bm => {
+            const colorCode = colorPalette.find(c => c.name === bm.color)?.code || '#ddd';
+            const isOtherDoc = bm.document_id !== window._currentDocId;
+            const card = document.createElement('div');
+            card.className = 'bm-card';
+            card.innerHTML = `
+                <div class="bm-card-top">
+                    <span class="bm-dot" style="background:${colorCode};"></span>
+                    ${isOtherDoc ? `<span style="font-size:10px;color:#94a3b8;margin-left:4px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:90px">${bm.documents?.file_name ?? ''}</span>` : ''}
+                    <button class="bm-delete-btn" title="삭제" style="margin-left:auto;background:none;border:none;cursor:pointer;color:#cbd5e1;font-size:16px;line-height:1;padding:2px 4px;border-radius:6px;transition:.15s;">×</button>
+                </div>
+                <div class="bm-body">
+                    <h3 class="bm-title">${bm.title || '제목 없음'}</h3>
+                    <p class="bm-content">${bm.memo || '내용이 비어있습니다.'}</p>
+                </div>
+            `;
+
+            card.querySelector('.bm-delete-btn').addEventListener('click', async (e) => {
+                e.stopPropagation();
+                if (bm.id) await deleteBookmarkFromDb(bm.id);
+                const localEntry = Object.entries(bookmarksData).find(([, d]) => d.dbId === bm.id);
+                if (localEntry) {
+                    const [localId, data] = localEntry;
+                    document.getElementById(data.tagElementId)?.remove();
+                    delete bookmarksData[localId];
+                    saveBookmarks();
+                }
+                card.remove();
+                if (!grid.querySelector('.bm-card')) {
+                    grid.innerHTML = '<div style="grid-column:1/-1;text-align:center;color:#a0a6b0;padding:40px;">저장된 북마크가 없습니다.</div>';
+                }
+            });
+            card.onclick = async () => {
+                overlay.classList.remove('show');
+                document.body.style.overflow = '';
+                if (isOtherDoc && typeof window.loadDocInViewer === 'function') {
+                    await window.loadDocInViewer(bm.document_id);
+                    const waitAndScroll = (retries = 0) => {
+                        const tagEl = document.querySelector(`.bookmark-tag[data-db-id="${bm.id}"]`);
+                        if (tagEl) {
+                            tagEl.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                        } else if (retries < 8) {
+                            setTimeout(() => waitAndScroll(retries + 1), 300);
+                        } else {
+                            const wrapper = document.querySelector('.main-wrapper');
+                            if (wrapper) wrapper.scrollTo({ top: bm.position_y, behavior: 'smooth' });
+                        }
+                    };
+                    setTimeout(() => waitAndScroll(), 500);
+                } else {
+                    const tagEl = document.querySelector(`.bookmark-tag[data-db-id="${bm.id}"]`)
+                               || (() => {
+                                   const localEntry = Object.values(bookmarksData).find(d => d.dbId === bm.id);
+                                   return localEntry ? document.getElementById(localEntry.tagElementId) : null;
+                               })();
                     if (tagEl) {
                         tagEl.scrollIntoView({ behavior: 'smooth', block: 'center' });
-                    } else if (retries < 8) {
-                        setTimeout(() => waitAndScroll(retries + 1), 300);
                     } else {
                         const wrapper = document.querySelector('.main-wrapper');
                         if (wrapper) wrapper.scrollTo({ top: bm.position_y, behavior: 'smooth' });
                     }
-                };
-                setTimeout(() => waitAndScroll(), 500);
-            } else {
-                // 현재 문서 → data-db-id 속성으로 태그 찾아 스크롤
-                const tagEl = document.querySelector(`.bookmark-tag[data-db-id="${bm.id}"]`)
-                           || (() => {
-                               const localEntry = Object.values(bookmarksData).find(d => d.dbId === bm.id);
-                               return localEntry ? document.getElementById(localEntry.tagElementId) : null;
-                           })();
-                if (tagEl) {
-                    tagEl.scrollIntoView({ behavior: 'smooth', block: 'center' });
-                } else {
-                    const wrapper = document.querySelector('.main-wrapper');
-                    if (wrapper) wrapper.scrollTo({ top: bm.position_y, behavior: 'smooth' });
                 }
-            }
-        };
-        grid.appendChild(card);
-    });
+            };
+            grid.appendChild(card);
+        });
+    }
 }
 
 document.getElementById('bookmarkOverlay').addEventListener('click', function (e) {

--- a/ui/viewer.html
+++ b/ui/viewer.html
@@ -130,6 +130,73 @@
     padding: 3px 7px;
 }
 
+/* 지식 자산 북마크 별표 */
+#page-viewer .sb-asset-bookmark {
+    flex-shrink: 0;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 2px 4px;
+    color: #d4d9e1;
+    font-size: 13px;
+    line-height: 1;
+    transition: color 0.15s, transform 0.15s;
+    border-radius: 4px;
+    opacity: 0;
+}
+#page-viewer .sb-item:hover .sb-asset-bookmark,
+#page-viewer .sb-asset-bookmark.active {
+    opacity: 1;
+}
+#page-viewer .sb-asset-bookmark:hover {
+    color: #fbbf24;
+    transform: scale(1.2);
+}
+#page-viewer .sb-asset-bookmark.active {
+    color: #f59e0b;
+}
+#page-viewer .sb-item.asset-bookmarked {
+    background: linear-gradient(90deg, #fffbeb 0%, #fff 100%);
+    border-left: 2px solid #f59e0b;
+    padding-left: 6px;
+}
+
+/* 북마크함 모달: 섹션 헤더 */
+.bm-section-header {
+    grid-column: 1 / -1;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 0 8px;
+    font-size: 14px;
+    font-weight: 700;
+    color: #64748b;
+    border-bottom: 1px solid #eef0f3;
+}
+.bm-section-header svg { flex-shrink: 0; }
+.bm-section-header:first-child { padding-top: 0; }
+
+/* 북마크함: 자산 카드 스타일 */
+.bm-card.asset-card {
+    border-left: 3px solid #f59e0b;
+    background: linear-gradient(135deg, #fffdf5 0%, #ffffff 100%);
+}
+.bm-card.asset-card:hover {
+    border-color: #f59e0b;
+    box-shadow: 0 20px 40px rgba(245,158,11,0.1);
+}
+.bm-asset-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 10px;
+    font-weight: 700;
+    color: #78a3ea;
+    background: #eef5ff;
+    border-radius: 999px;
+    padding: 3px 8px;
+}
+
 /* mainpage 프로필 영역 그대로 */
 #page-viewer .sidebar-profile {
     padding: 14px 16px;
@@ -1618,6 +1685,24 @@
             console.warn('문서 목록 로드 실패:', e.message)
         }
 
+        // ── 지식 자산 북마크 (localStorage) ────────────────
+        const ASSET_BM_KEY = `nungil_asset_bm_${userId}`
+
+        function getAssetBookmarks() {
+            try {
+                const raw = localStorage.getItem(ASSET_BM_KEY)
+                return new Set(raw ? JSON.parse(raw) : [])
+            } catch { return new Set() }
+        }
+
+        function saveAssetBookmarks(bmSet) {
+            localStorage.setItem(ASSET_BM_KEY, JSON.stringify([...bmSet]))
+        }
+
+        // 전역 노출: script.js(북마크함 모달)에서 접근
+        window._getAssetBookmarks = getAssetBookmarks
+        window._saveAssetBookmarks = saveAssetBookmarks
+
         // ── 지식 자산 로드 함수 (common.js의 saveAssetToDb에서 window로 호출)
         window.loadKnowledgeAssets = loadKnowledgeAssets
         async function loadKnowledgeAssets(targetDocId) {
@@ -1662,17 +1747,49 @@
 
                 const typeLabel = { SUMMARY: '요약', MINDMAP: '마인드맵', QUIZ: '퀴즈' }
 
+                // 북마크 상태 로드 & 북마크된 자산 상단 정렬
+                const assetBm = getAssetBookmarks()
+                assets.sort((a, b) => {
+                    const aKey = `${a.document_id}_${a.type}`
+                    const bKey = `${b.document_id}_${b.type}`
+                    return (assetBm.has(bKey) ? 1 : 0) - (assetBm.has(aKey) ? 1 : 0)
+                })
+
                 assetEl.innerHTML = assets.map(a => {
                     const fname = cleanDocTitle(a.documents?.file_name ?? '')
                     const label = `${fname} ${typeLabel[a.type] ?? a.type}`
+                    const assetKey = `${a.document_id}_${a.type}`
+                    const isBm = assetBm.has(assetKey)
 
                     return `
-                    <button class="sb-item" data-tool="${toolName[a.type]}" data-doc-id="${a.document_id}" data-asset-id="${a.id}" style="gap:8px;align-items:center;">
+                    <button class="sb-item${isBm ? ' asset-bookmarked' : ''}" data-tool="${toolName[a.type]}" data-doc-id="${a.document_id}" data-asset-id="${a.id}" data-asset-key="${assetKey}" style="gap:8px;align-items:center;">
                         <span style="flex-shrink:0;display:flex;align-items:center;color:#78a3ea">${typeIcon[a.type]}</span>
                         <span class="sb-item-text" style="font-size:12px;">${fname} ${typeLabel[a.type] ?? a.type}</span>
+                        <span class="sb-asset-bookmark${isBm ? ' active' : ''}" data-asset-key="${assetKey}" title="북마크">${isBm ? '★' : '☆'}</span>
                         <span class="sb-item-delete" data-delete-type="asset" data-delete-id="${a.id}" data-delete-name="${label}">×</span>
                     </button>`
                 }).join('')
+
+                // 북마크 별표 클릭 이벤트
+                assetEl.querySelectorAll('.sb-asset-bookmark').forEach(star => {
+                    star.addEventListener('click', (e) => {
+                        e.stopPropagation()
+                        const key = star.dataset.assetKey
+                        const currentBm = getAssetBookmarks()
+                        if (currentBm.has(key)) {
+                            currentBm.delete(key)
+                            star.classList.remove('active')
+                            star.textContent = '☆'
+                            star.closest('.sb-item')?.classList.remove('asset-bookmarked')
+                        } else {
+                            currentBm.add(key)
+                            star.classList.add('active')
+                            star.textContent = '★'
+                            star.closest('.sb-item')?.classList.add('asset-bookmarked')
+                        }
+                        saveAssetBookmarks(currentBm)
+                    })
+                })
 
                 assetEl.querySelectorAll('.sb-item-delete').forEach(btn => {
                     btn.addEventListener('click', (e) => {
@@ -1681,9 +1798,10 @@
                     })
                 })
 
+                // 자산 항목 클릭 → AI 도구 열기
                 assetEl.querySelectorAll('.sb-item').forEach(el => {
                     el.addEventListener('click', async (e) => {
-                        if (e.target.closest('.sb-item-delete')) return
+                        if (e.target.closest('.sb-item-delete') || e.target.closest('.sb-asset-bookmark')) return
                         const tool   = el.dataset.tool
                         const dId    = el.dataset.docId
 


### PR DESCRIPTION
## Summary
- 사이드바 지식 자산 항목에 별(★) 토글로 북마크 기능 추가
- 북마크된 자산은 상단 정렬 + 노란색 테두리로 시각 구분
- localStorage 기반 영속화, 북마크함 모달에 자산 북마크 섹션 통합

## 변경 파일
- `ui/viewer.html` — 북마크 CSS, 헬퍼 함수, loadKnowledgeAssets 내 별 토글 UI/이벤트
- `ui/script.js` — togBookmarkList()에 자산 북마크 섹션 렌더링 추가

## Test plan
- [x] 지식 자산 항목에 마우스 올리면 ★ 버튼 표시 확인
- [ ] ★ 클릭 시 북마크 토글 및 시각 변화 확인
- [ ] 새로고침 후에도 북마크 상태 유지 확인
- [ ] 북마크함(모달)에서 자산 북마크 카드 표시 확인
- [ ] 자산 카드 클릭 시 해당 문서 뷰어로 이동 + AI 도구 자동 열기 확인
- [ ] 북마크함에서 별 해제 시 카드 제거 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)