### PR TITLE
fix: doc-changed 중복 렌더 race condition 수정

### DIFF
--- a/ui/ai/index.js
+++ b/ui/ai/index.js
@@ -27,7 +27,7 @@ window.addEventListener("viewer-init", () => {
 });
 
 // 문서 in-place 전환 시 AI state 재초기화 + 원본 버튼으로 초기화
-window.addEventListener("doc-changed", async () => {
+window.addEventListener("doc-changed", async (e) => {
   initAiState();
 
   currentTool = "original";
@@ -38,6 +38,29 @@ window.addEventListener("doc-changed", async () => {
 
   const origBtn = document.querySelector('.sb-tool-item[data-ai-tool="original"]');
   if (origBtn) origBtn.classList.add("active");
+
+  // loadDocInViewer에서 이미 PDF를 렌더한 경우 중복 렌더 방지
+  if (e.detail?.skipRender) {
+    clearAiMode();
+    document.body.classList.remove(
+      "quiz-inline-mode",
+      "quiz-fullscreen-mode",
+      "summary-mode",
+      "mindmap-mode",
+      "quiz-mode",
+      "ai-view-mode"
+    );
+    const container = document.getElementById("pdfContainer");
+    if (container) {
+      container.classList.remove(
+        "summary-mode",
+        "quiz-mode",
+        "mindmap-mode",
+        "ai-loading-mode"
+      );
+    }
+    return;
+  }
 
   await renderOriginalDocument();
 });

--- a/ui/viewer.html
+++ b/ui/viewer.html
@@ -1352,8 +1352,8 @@
                 // 지식 자산 갱신
                 loadKnowledgeAssets(id)
 
-                // AI 모듈 상태 재초기화
-                window.dispatchEvent(new CustomEvent('doc-changed'))
+                // AI 모듈 상태 재초기화 (skipRender: loadDocInViewer가 이미 PDF를 렌더했으므로 중복 렌더 방지)
+                window.dispatchEvent(new CustomEvent('doc-changed', { detail: { skipRender: true } }))
 
                 // 워크스페이스 세션 유지 — 현재 문서만 갱신
                 if (S.sessionId) {


### PR DESCRIPTION
## Summary
- `loadDocInViewer`에서 PDF 렌더 후 `doc-changed` 이벤트를 발행하면, AI 모듈이 동일 PDF를 다시 렌더하는 race condition 수정
- `doc-changed` 이벤트에 `skipRender: true` 플래그를 전달하여, AI 모듈이 상태 초기화만 수행하고 중복 렌더를 건너뜀

## 변경 파일
- `ui/viewer.html`: CustomEvent에 `{ detail: { skipRender: true } }` 추가
- `ui/ai/index.js`: `skipRender` 플래그 확인 후 클래스 정리만 수행, `renderOriginalDocument()` 호출 생략